### PR TITLE
fix: 잘못된 detail/:id 경로를 detail/:lectureId 로 수정

### DIFF
--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -38,7 +38,7 @@ export const router = createBrowserRouter([
         path: 'lectures',
         children: [
           { index: true, element: <LectureList /> },
-          { path: 'detail/:id', element: <LectureDetail /> },
+          { path: 'detail/:lectureId', element: <LectureDetail /> },
         ],
       },
     ],


### PR DESCRIPTION
## 변경 사항

- Merge 과정에서 기존 라우트 경로(detail/:id)가 덮어써지면서 LectureDetail 페이지가 정상적으로 렌더링되지 않는 문제가 발생했습니다.
   라우트 파라미터명을 `:lectureId`로 복구하여 정상 작동하도록 수정했습니다.


## 리뷰 필요

- [ ] http://localhost:3000/detail/lec001 접근 시 정상 렌더링 확인


close #20 