### PR TITLE
feat: Header 꾸미기 (로그인 조건 별 버튼 구성)

### DIFF
--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -4,6 +4,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { login } from '../../store/auth/login.js';
 import { useNavigate } from 'react-router-dom';
 import { clearError } from '../../store/auth/authSlice.js';
+import InputPassword from '../common/form/InputPassword.jsx';
+import GlobalLoading from '../loading/GlobalLoading.jsx';
+import ErrorMessage from '../ui/ErrorMessage.jsx';
 
 const LoginForm = () => {
   const navigate = useNavigate();
@@ -31,50 +34,53 @@ const LoginForm = () => {
   };
 
   return (
-    <form className="space-y-5" onSubmit={handleSubmit}>
-      <Input
-        label="이메일"
-        id="email"
-        name="email"
-        type="text"
-        value={formData.email}
-        onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-        aria-required="true"
-        placeholder="example@lxp.com"
-        required
-      />
-
-      <Input
-        label="비밀번호"
-        id="password"
-        name="password"
-        type="password"
-        value={formData.password}
-        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-        aria-required="true"
-        placeholder="8자 이상 입력하세요"
-        required
-      />
-
-      {/* <!-- Remember Me Checkbox --> */}
-      <div className="flex items-center">
-        <input
-          type="checkbox"
-          id="remember-me"
-          name="remember-me"
-          className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-2 focus:ring-gray-900"
+    <>
+      <form className="space-y-5" onSubmit={handleSubmit}>
+        <Input
+          label="이메일"
+          id="email"
+          name="email"
+          type="text"
+          value={formData.email}
+          onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+          aria-required="true"
+          placeholder="example@lxp.com"
+          required
         />
-        <label className="ml-2 text-sm text-gray-700">로그인 상태 유지</label>
-      </div>
 
-      {/* <!-- Submit Button --> */}
-      <button
-        type="submit"
-        className="w-full rounded-lg bg-gray-900 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-gray-800 focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-gray-300"
-      >
-        로그인
-      </button>
-    </form>
+        <InputPassword
+          label="비밀번호"
+          id="password"
+          name="password"
+          value={formData.password}
+          onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+          aria-required="true"
+          placeholder="8자 이상 입력하세요"
+          required
+        />
+
+        {/* <!-- Remember Me Checkbox --> */}
+        <div className="flex items-center">
+          <input
+            type="checkbox"
+            id="remember-me"
+            name="remember-me"
+            className="h-4 w-4 rounded border-gray-300 text-gray-900 focus:ring-2 focus:ring-gray-900"
+          />
+          <label className="ml-2 text-sm text-gray-700">로그인 상태 유지</label>
+        </div>
+
+        {/* <!-- Submit Button --> */}
+        <button
+          type="submit"
+          className="w-full rounded-lg bg-gray-900 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-gray-800 focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          로그인
+        </button>
+        {error && <ErrorMessage message={error} />}
+      </form>
+      {loading ? <GlobalLoading mention="로그인 중 입니다..." /> : null}
+    </>
   );
 };
 

--- a/src/components/auth/signupForm.jsx
+++ b/src/components/auth/signupForm.jsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom';
 import { clearError } from '../../store/auth/authSlice.js';
 import { signup } from '../../store/auth/signup.js';
 import Input from '../common/form/Input.jsx';
+import InputPassword from '../common/form/InputPassword.jsx';
+import ErrorMessage from '../ui/ErrorMessage.jsx';
 
 const SignupForm = () => {
   const [formData, setFormData] = useState({
@@ -93,11 +95,10 @@ const SignupForm = () => {
         required
       />
 
-      <Input
+      <InputPassword
         label="비밀번호"
         id="password"
         name="password"
-        type="password"
         value={formData.password}
         onChange={handleChange}
         aria-required="true"
@@ -105,11 +106,10 @@ const SignupForm = () => {
         required
       />
 
-      <Input
+      <InputPassword
         label="비밀번호 확인"
         id="passwordConfirm"
         name="passwordConfirm"
-        type="password"
         value={formData.passwordConfirm}
         onChange={handleChange}
         aria-required="true"
@@ -118,11 +118,7 @@ const SignupForm = () => {
       />
 
       {/* 에러 메시지 */}
-      {mergedError && (
-        <p className="text-sm text-rose-600" role="alert" aria-live="polite">
-          {mergedError}
-        </p>
-      )}
+      {mergedError && <ErrorMessage message={mergedError} />}
 
       {/* 제출 버튼 */}
       <button

--- a/src/components/common/form/Input.jsx
+++ b/src/components/common/form/Input.jsx
@@ -47,29 +47,6 @@ export default function Input({
         ].join(' ')}
         placeholder={placeholder}
       />
-      {type === 'password' && (
-        <button
-          type="button"
-          className="absolute right-3 bottom-[15px] text-gray-400 hover:text-gray-600 focus:outline-none"
-          aria-label="비밀번호 표시/숨기기"
-          tabIndex={-1}
-        >
-          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-            />
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-            />
-          </svg>
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/common/form/InputPassword.jsx
+++ b/src/components/common/form/InputPassword.jsx
@@ -11,24 +11,19 @@ import Required from '../../ui/Required.jsx';
  * @property {boolean} [required=true]
  * @property {string} [placeholder='홍길동']
  * @property {string} [className='']
- * @property {'text'|'email'|'password'} [type='text']
  */
-export default function Input({
+export default function InputPassword({
   name,
   id,
-  label = '이름',
-  value = '',
+  label,
+  value,
   onChange,
   required = true,
-  placeholder = '홍길동',
-  className = '',
-  type = 'text',
+  placeholder,
+  className,
 }) {
   const inputId = id || name;
   const [showPw, setShowPw] = useState(false);
-
-  const isPassword = type === 'password';
-  const inputType = isPassword && showPw ? 'text' : type;
 
   return (
     <div className="relative">
@@ -36,8 +31,9 @@ export default function Input({
         {label} {required && <Required />}
       </label>
 
+      {/* 핵심: type을 상태로 토글 */}
       <input
-        type={inputType}
+        type={showPw ? 'text' : 'password'}
         id={inputId}
         name={name}
         required={required}
@@ -45,59 +41,54 @@ export default function Input({
         value={value}
         onChange={onChange}
         className={[
-          'w-full rounded-lg border border-gray-300 px-4 py-3 text-base transition-colors',
+          'peer w-full rounded-lg border border-gray-300 px-4 py-3 text-base transition-colors',
           'placeholder:text-gray-400 focus:border-transparent focus:ring-2 focus:ring-gray-900 focus:outline-none',
           className,
-          isPassword ? 'pr-10' : '',
+          'pr-10', // 버튼 공간
         ].join(' ')}
         placeholder={placeholder}
-        autoComplete={isPassword ? 'current-password' : undefined}
+        autoComplete="current-password"
       />
 
-      {isPassword && (
-        <button
-          type="button"
-          onClick={() => setShowPw((v) => !v)}
-          className="absolute right-3 bottom-[15px] text-gray-400 hover:text-gray-600 focus:outline-none"
-          aria-label={showPw ? '비밀번호 숨기기' : '비밀번호 표시'}
-          aria-pressed={showPw}
-          title={showPw ? '비밀번호 숨기기' : '비밀번호 표시'}
-        >
-          {showPw ? (
-            // eye-off
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M3 3l18 18M9.88 9.88A3 3 0 0112 9c1.657 0 3 1.343 3 3a3 3 0 01-.88 2.12M7.05 7.05C5.24 8.2 3.78 9.91 2.458 12 3.732 16.057 7.522 19 12 19c1.52 0 2.96-.34 4.24-.95M14.12 14.12A3 3 0 0112 15c-1.657 0-3-1.343-3-3 0-.53.138-1.027.38-1.46"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M12 5c4.478 0 8.268 2.943 9.542 7a11.94 11.94 0 01-2.308 3.592"
-              />
-            </svg>
-          ) : (
-            // eye
-            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
-          )}
-        </button>
-      )}
+      <button
+        type="button"
+        onMouseDown={(e) => e.preventDefault()} // 입력창 포커스 유지
+        onClick={() => setShowPw((v) => !v)}
+        className="absolute top-1/2 right-3 rounded p-1 text-gray-400 transition-colors hover:text-gray-600 focus:outline-none"
+        aria-label={showPw ? '비밀번호 숨기기' : '비밀번호 표시'}
+        aria-pressed={showPw}
+        title={showPw ? '비밀번호 숨기기' : '비밀번호 표시'}
+      >
+        {/* 아이콘 토글: eye / eye-off */}
+        {showPw ? (
+          // eye-off
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M13.875 18.825A10.05 10.05 0 0112 19c-4.477 0-8.268-2.943-9.542-7a10.65 10.65 0 012.62-4.17M9.88 9.88a3 3 0 104.24 4.24"
+            />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6.1 6.1L18 18" />
+          </svg>
+        ) : (
+          // eye
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+          </svg>
+        )}
+      </button>
     </div>
   );
 }

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { logout } from '../../store/auth/logout.js';
+import SkeletonButton from '../ui/SkeletonButton.jsx';
 
 function Header() {
   const navigate = useNavigate();
@@ -39,7 +40,12 @@ function Header() {
           {/* <!-- Navigation & Auth Section --> */}
           <div className="flex flex-shrink-0 items-center space-x-4">
             <div className="hidden items-center space-x-3 md:flex">
-              {initializing ? null : user ? (
+              {initializing ? (
+                <>
+                  <SkeletonButton className="h-5 w-16 rounded" />
+                  <SkeletonButton className="h-9 w-20 rounded-lg" />
+                </>
+              ) : user ? (
                 <>
                   <button
                     onClick={() => handleNavi('/mypage')}

--- a/src/components/loading/GlobalLoading.jsx
+++ b/src/components/loading/GlobalLoading.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Loading from './loadingBody/Loading.jsx';
+
+const GlobalLoading = ({ mention }) => {
+  return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center gap-2 font-bold">
+      <Loading />
+      {mention && <p>{mention}</p>}
+    </div>
+  );
+};
+
+export default GlobalLoading;

--- a/src/components/loading/loadingBody/Loading.jsx
+++ b/src/components/loading/loadingBody/Loading.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './loading.css';
+
+const Loading = () => {
+  return <div className="loader"></div>;
+};
+
+export default Loading;

--- a/src/components/loading/loadingBody/loading.css
+++ b/src/components/loading/loadingBody/loading.css
@@ -1,0 +1,12 @@
+.loader {
+  width: 15px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  animation: l5 1s infinite linear alternate;
+}
+@keyframes l5 {
+  0%  {box-shadow: 20px 0 #000, -20px 0 #0002;background: #000 }
+  33% {box-shadow: 20px 0 #000, -20px 0 #0002;background: #0002}
+  66% {box-shadow: 20px 0 #0002,-20px 0 #000; background: #0002}
+  100%{box-shadow: 20px 0 #0002,-20px 0 #000; background: #000 }
+}

--- a/src/components/ui/ErrorMessage.jsx
+++ b/src/components/ui/ErrorMessage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ErrorMessage = ({ message }) => {
+  return (
+    <p className="text-sm text-rose-600" role="alert" aria-live="polite">
+      {message}
+    </p>
+  );
+};
+
+export default ErrorMessage;

--- a/src/components/ui/SkeletonButton.jsx
+++ b/src/components/ui/SkeletonButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const SkeletonButton = ({ className = '' }) => {
+  return (
+    <span
+      aria-hidden="true"
+      className={['inline-block animate-pulse rounded bg-gray-200', className].join(' ')}
+    />
+  );
+};
+
+export default SkeletonButton;


### PR DESCRIPTION
## 변경 사항

- 비 로그인시 -> ["로그인" 버튼, "회원가입"버튼]
- 로그인시 -> ["마이페이지" 버튼, "로그아웃"버튼]
- 로딩 컴포넌트 추가
- inputPassword 컴포넌트 추가 -> 비밀번호 보는 것 가능 하게

## 리뷰 필요

- 헤더 페이지 조건에 따라서 표시 
- 헤더 페이지 버튼 로딩시 스켈레톤화
- 로딩 컴포넌트 생성
- InputPassword 컴포넌트 갈아끼우기
close #14 