### PR TITLE
fix: 마이페이지 [수강 중인 강의] 카드 카테고리 id에 맞춰 표기 변 #42

### DIFF
--- a/src/components/mypage/my-lectures/MyLectureCard.jsx
+++ b/src/components/mypage/my-lectures/MyLectureCard.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import CATEGORIES from '../../../constants/categories.js';
 
 const MyLectureCard = (props) => {
   const {
@@ -15,6 +16,7 @@ const MyLectureCard = (props) => {
     userId,
     userName,
   } = props;
+  const cat = CATEGORIES.find((e) => e.id === category);
   const navigate = useNavigate();
 
   const handleMoveToDetail = () => {
@@ -42,7 +44,7 @@ const MyLectureCard = (props) => {
           <div className="mb-3 flex items-start justify-between">
             <div className="flex-1">
               <span className="mb-2 inline-block rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-900">
-                {typeof category === 'string' ? category : `카테고리 ${category}`}
+                {cat.name}
               </span>
 
               <h3 className="mb-2 text-lg font-bold text-gray-900">{title}</h3>


### PR DESCRIPTION
## 변경 사항

- 카테고리 Id에 해당하는 아이디 보이게 하기

## 리뷰 필요

- 마이페이지 [수강 중인 강의] 카드 카테고리 변경 사항 확인 -> 이미지(에비던스) 확인
<img width="937" height="294" alt="image" src="https://github.com/user-attachments/assets/d12a7e8d-173b-4f4f-a562-d229eeff4b6d" />

close #42 