### PR TITLE
fix: 수강 신청한 목록 화면 상태 표시 영문 ⇒ 한글로 변경 #77

### DIFF
--- a/src/components/mypage/my-lectures/EnrolledCard.jsx
+++ b/src/components/mypage/my-lectures/EnrolledCard.jsx
@@ -3,6 +3,7 @@ import { ChevronRight, BookOpen } from 'lucide-react';
 import { fmtDate } from '../../../utils/fmtDate.js';
 import CATEGORIES from '../../../constants/categories.js';
 import { useNavigate } from 'react-router-dom';
+import StatusTag from './enrolled-card/StatusTag.jsx';
 
 export function EnrolledCard({ status, enrolledAt, reviews, lecture }) {
   const title = lecture?.title ?? '(삭제된 강의)';
@@ -58,21 +59,7 @@ export function EnrolledCard({ status, enrolledAt, reviews, lecture }) {
               <span>수강 신청일 {fmtDate(enrolledAt)}</span>
             </div>
 
-            {status === 'completed' ? (
-              <span className="rounded-md bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
-                수료
-              </span>
-            ) : status === 'active' ? (
-              <span className="rounded-md bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">
-                수강 중
-              </span>
-            ) : (
-              status && (
-                <span className="rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
-                  {status}
-                </span>
-              )
-            )}
+            <StatusTag status={status} />
           </div>
 
           {/* 액션 */}

--- a/src/components/mypage/my-lectures/enrolled-card/StatusTag.jsx
+++ b/src/components/mypage/my-lectures/enrolled-card/StatusTag.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+const STATUS_STYLES = {
+  active: {
+    text: '수강 중',
+    className: 'bg-indigo-50 text-indigo-700',
+  },
+  completed: {
+    text: '수료',
+    className: 'bg-green-50 text-green-700',
+  },
+  cancelled: {
+    text: '취소됨',
+    className: 'bg-red-50 text-red-700',
+  },
+  expired: {
+    text: '만료됨',
+    className: 'bg-gray-50 text-gray-600',
+  },
+  paused: {
+    text: '일시 중지',
+    className: 'bg-yellow-50 text-yellow-700',
+  },
+};
+
+const StatusTag = ({ status }) => {
+  const statusInfo = STATUS_STYLES[status] ?? {
+    text: status ?? '',
+    className: 'bg-gray-100 text-gray-700',
+  };
+
+  return (
+    <span className={`rounded-md px-2 py-0.5 text-xs font-medium ${statusInfo.className}`}>
+      {statusInfo.text}
+    </span>
+  );
+};
+
+export default StatusTag;


### PR DESCRIPTION
## 변경 사항

- 수강 신청한 목록 화면 상태 표시 영문 ⇒ 한글로 변경

## 리뷰 필요

- 문구 변경 [ 'active', 'completed', 'cancelled', 'expired', 'paused' ]

- active: 수강중 -> 인디고

- completed: 수료 -> 초록

- cancel: 취소됨 -> 레드

- expird: 만료됨 -> 그레이

- paused: 일시 중지 -> 노랑

close #77 