### PR TITLE
fix: Shorts Detail 목록 8개 제한 문제 해결

### DIFF
--- a/src/app/(fullscreen)/shorts/[id]/page.tsx
+++ b/src/app/(fullscreen)/shorts/[id]/page.tsx
@@ -9,6 +9,7 @@ interface ShortDetailPageProps {
 export default async function ShortformDetailPage({ params }: ShortDetailPageProps) {
   const { id } = await params
   const data = await getShortsDetailList(id)
+  // console.log('데이터 불러오기:', data)
 
   if (!data) {
     notFound()

--- a/src/app/(general)/page.tsx
+++ b/src/app/(general)/page.tsx
@@ -7,7 +7,7 @@ import { getShortPopular } from '@/services/getShortPopular'
 
 export default async function Page() {
   const popularShorts = await getShortPopular()
-  console.log(popularShorts)
+  // console.log(popularShorts)
   return (
     <div className="min-h-screen bg-white">
       <ShortFormCarousel data={popularShorts?.data?.content} />

--- a/src/features/shortform/components/ShortsContainer.tsx
+++ b/src/features/shortform/components/ShortsContainer.tsx
@@ -104,7 +104,7 @@ export default function ShortsContainer({ shortsList, initialIndex }: ShortsCont
         <div className="h-[84vh] w-full overflow-hidden bg-black sm:rounded-2xl md:h-[84vh]">
           <AnimatePresence initial={false} custom={slideDirection} mode="wait">
             <motion.div
-              key={currentShorts.id}
+              key={currentShorts.shortsId}
               custom={slideDirection}
               variants={slideVariants}
               initial="enter"

--- a/src/features/shortform/components/ShortsNavigationButtons.tsx
+++ b/src/features/shortform/components/ShortsNavigationButtons.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { ArrowDown, ArrowUp } from 'lucide-react'
 
 interface ShortsNavigationButtonsProps {

--- a/src/hook/useDragNavigation.ts
+++ b/src/hook/useDragNavigation.ts
@@ -1,3 +1,4 @@
+'use client'
 import { PanInfo } from 'framer-motion'
 import { useCallback } from 'react'
 

--- a/src/hook/useKeyboardNavigation.ts
+++ b/src/hook/useKeyboardNavigation.ts
@@ -1,3 +1,4 @@
+'use client'
 import { useEffect } from 'react'
 
 interface UseKeyboardNavigationProps {

--- a/src/services/shorts/getShortsDetailList.ts
+++ b/src/services/shorts/getShortsDetailList.ts
@@ -15,7 +15,9 @@ export interface ShortsListProps {
 export async function getShortsDetailList(startId: string): Promise<ShortsListProps | null> {
   try {
     // 1: API 호출
-    const response = await shortsApi.shortsDetailList()
+    const response = await shortsApi.shortsDetailList({ page: 0, size: 20 })
+
+    // console.log('data:', response)
 
     // 2: 페이징 응답에서 실제 배열 추출
     let allShorts: ShortsDetail[]
@@ -52,7 +54,7 @@ export async function getShortsDetailList(startId: string): Promise<ShortsListPr
     }
 
     // 6: 시작 지점 기준으로 10개 추출
-    const beforeCount = Math.min(startIndex, 2)
+    const beforeCount = Math.min(startIndex, 0)
     const startSlice = startIndex - beforeCount
     const endSlice = Math.min(startSlice + 10, sortedShorts.length)
 

--- a/src/services/shorts/shorts.service.ts
+++ b/src/services/shorts/shorts.service.ts
@@ -3,9 +3,13 @@ import api from '@/lib/utils/apiUtils'
 const apiClient = api()
 
 export const shortsApi = {
-  shortsDetailList: async () => {
+  shortsDetailList: async ({ page = 0, size = 20 }) => {
     const response = await apiClient.get('/api/v1/shorts', {
       cache: 'no-store',
+      params: {
+        page,
+        size,
+      },
     })
     return response
   },


### PR DESCRIPTION
## 변경 사항

- shortsApi.shortsDetailList 메서드 page, size 파라미터 추가
- 커스텀 훅 클리언트 컴포넌트 선언 추가
- 네비게이션 버튼 클릭 이벤트 수정

## 리뷰 필요

- 숏츠 목록 시작지점으로부터 10개인지 확인
- 네비게이션(스와이프) 작동 



close #139 