### PR TITLE
feat: shorts description 토글 기능 추가

### DIFF
--- a/src/features/shortform/components/ShortsCreateInfo.tsx
+++ b/src/features/shortform/components/ShortsCreateInfo.tsx
@@ -1,5 +1,6 @@
 import { User } from 'lucide-react'
 import { ShortsUploader } from '../../../types/shortform'
+import ShortsToggleDescription from './ShortsToggleDescription'
 
 interface ShortsCreateInfoProps {
   uploader: ShortsUploader
@@ -9,7 +10,7 @@ interface ShortsCreateInfoProps {
 
 export default function ShortsCreateInfo({ uploader, title, description }: ShortsCreateInfoProps) {
   return (
-    <div className="w-full from-black/80 to-transparent px-4 py-8 text-white">
+    <div className="w-[86%] from-black/80 to-transparent px-4 py-8 text-white">
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
           {uploader.profileUrl ? (
@@ -19,15 +20,20 @@ export default function ShortsCreateInfo({ uploader, title, description }: Short
               className="h-full w-full object-cover"
             />
           ) : (
-            <User strokeWidth={1.5} color="#333" />
+            <>
+              <div className="h-10 w-10 rounded-full bg-gray-300">
+                <User strokeWidth={1.5} color="white" />
+              </div>
+            </>
           )}
         </div>
-        <div>
-          <p className="font-medium">{uploader.nickname}</p>
-          <p className="text-sm opacity-90">{title}</p>
-        </div>
+
+        <p className="block font-medium">{uploader.nickname}</p>
       </div>
-      <p className="mt-3 text-sm leading-relaxed opacity-90">{description}</p>
+      <div className="pt-4">
+        <p className="text-lg font-bold opacity-90">{title}</p>
+      </div>
+      <ShortsToggleDescription description={description} />
     </div>
   )
 }

--- a/src/features/shortform/components/ShortsPlayer.tsx
+++ b/src/features/shortform/components/ShortsPlayer.tsx
@@ -25,8 +25,8 @@ export default function ShortsPlayer({ videoUrl, thumbnailUrl }: ShortsPlayerPro
       key={videoUrl}
       aria-label="shorts video player"
       className="h-full w-full object-cover"
-      controls
       autoPlay
+      controls
       muted
       loop
       playsInline

--- a/src/features/shortform/components/ShortsToggleDescription.tsx
+++ b/src/features/shortform/components/ShortsToggleDescription.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useState } from 'react'
+
+interface ShortsToggleDescriptionProps {
+  description: string
+}
+
+export default function ShortsToggleDescription({ description }: ShortsToggleDescriptionProps) {
+  const [isToggled, setIsToggled] = useState(false)
+
+  return (
+    <div className="mt-3">
+      <p className={`text-xs leading-relaxed opacity-90 ${isToggled ? '' : 'line-clamp-2'}`}>
+        {description}
+      </p>
+
+      {description.length > 60 && (
+        <button
+          onClick={() => setIsToggled(!isToggled)}
+          className="mt-1 text-xs font-medium opacity-70 transition-opacity hover:opacity-100"
+        >
+          {isToggled ? '접기' : '더보기'}
+        </button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 변경 사항

- ShortsToggleDescription 컴포넌트 분리 (클라이언트 컴포넌트) 
- 설명이 2줄 이상일 경우 '더보기' 버튼으로 토글 가능

## 리뷰 필요

- 비디오 설명 텍스트에 더보기/접기 기능 추가
  - 2줄 이상의 긴 설명 텍스트 자동 말줄임 처리 (line-clamp-2)
  - 60자 이상일 때 더보기/접기 버튼 표시
  - useState로 펼침/접힘 상태 관리
  - 호버 시 opacity 전환 효과 추가


close #143 