### PR TITLE
feat: Error 페이지 화면 구현

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,32 @@
 'use client'
 
+import { TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+
 export default function Error() {
-  return <div className=""></div>
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md text-center">
+        {/* 에러 아이콘 */}
+        <div className="mb-8">
+          <div className="inline-flex h-20 w-20 items-center justify-center rounded-full bg-red-50">
+            <TriangleAlert strokeWidth={1.5} color="red" size={32} />
+          </div>
+        </div>
+
+        {/* 에러 메시지 */}
+        <h1 className="mb-3 text-2xl font-bold text-gray-900">문제가 발생했습니다.</h1>
+        <p className="text-gray-600">
+          잠시 후 다시 시도해 주세요.
+          <br />
+          <Link
+            href="/"
+            className="mt-4 inline-block cursor-pointer rounded-full border border-gray-300 px-5 py-2 text-sm font-medium transition hover:bg-gray-100"
+          >
+            홈으로 돌아가기
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 export default function NotFound() {
   return (
     <div className="flex min-h-screen items-center justify-center px-6">
@@ -5,12 +7,12 @@ export default function NotFound() {
         <p className="mb-2 text-6xl font-bold">404</p>
         <h1 className="mb-3 text-xl font-semibold">페이지를 찾을 수 없어요</h1>
 
-        <a
+        <Link
           href="/"
-          className="inline-block rounded-full border border-gray-300 px-5 py-2 text-sm font-medium transition hover:bg-gray-100"
+          className="inline-block cursor-pointer rounded-full border border-gray-300 px-5 py-2 text-sm font-medium transition hover:bg-gray-100"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   )

--- a/src/features/home/ShortFormCarousel/ShortFormCarousel.tsx
+++ b/src/features/home/ShortFormCarousel/ShortFormCarousel.tsx
@@ -10,7 +10,7 @@ export default function ShortFormCarousel({ data }: { data?: ShortsItem[] }) {
   return (
     <section className="mb-12">
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="flex items-center gap-2 text-2xl font-extrabold text-gray-900 uppercase">
+        <h2 className="flex items-center gap-2 text-xl font-extrabold text-gray-900 uppercase">
           Dev's Hot Pick?
         </h2>
         <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500">

--- a/src/features/home/lecture/CategoryLectureSection.tsx
+++ b/src/features/home/lecture/CategoryLectureSection.tsx
@@ -23,7 +23,7 @@ export default function CategoryLectureSection({ lectures }: { lectures: Lecture
   return (
     <section className="mb-12">
       <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-2xl font-extrabold text-gray-900 uppercase">Categories</h2>
+        <h2 className="text-xl font-extrabold text-gray-900 uppercase">Categories</h2>
         <Link
           href="/"
           className="text-sm font-medium text-gray-500 transition-colors hover:text-gray-900"

--- a/src/features/home/play-list-section/PlaylistSection.tsx
+++ b/src/features/home/play-list-section/PlaylistSection.tsx
@@ -5,7 +5,7 @@ import PlaylistButton from '@/features/home/play-list-section/PlaylistButton'
 export default async function PlaylistSection({ items }: { items: PlaylistItem[] }) {
   return (
     <section className="mb-12">
-      <h2 className="mb-6 text-2xl font-extrabold text-gray-900 uppercase">Knowledge Blocks</h2>
+      <h2 className="mb-6 text-xl font-extrabold text-gray-900 uppercase">Knowledge Blocks</h2>
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {items.map((item) => (
           <PlaylistButton key={item.id}>

--- a/src/features/shortform/components/ShortsCreateInfo.tsx
+++ b/src/features/shortform/components/ShortsCreateInfo.tsx
@@ -21,7 +21,7 @@ export default function ShortsCreateInfo({ uploader, title, description }: Short
             />
           ) : (
             <>
-              <div className="h-10 w-10 rounded-full bg-gray-300">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-400">
                 <User strokeWidth={1.5} color="white" />
               </div>
             </>


### PR DESCRIPTION
## 변경 사항

- Error  페이지 화면 구현


## 리뷰 필요

- `test-error/page.tsx ` 생성 후 해당 링크 접속 시 확인 가능
- 캡쳐이미지

<img width="1208" height="748" alt="image" src="https://github.com/user-attachments/assets/1cfa208a-e493-4ef7-821b-2c6e192baf2b" />



close #156 