### PR TITLE
fix: 숏츠 등록 타입 에러 수정

### DIFF
--- a/src/features/category.action.ts
+++ b/src/features/category.action.ts
@@ -1,7 +1,9 @@
 'use server'
 
 import { categoryApi, type CategoryResponse } from '@/services/category/category.service'
+import { ApiResponse } from '@/types/mypage-shorts'
 
-export async function getCategoriesAction(): Promise<CategoryResponse> {
-  return categoryApi.getAll()
+export async function getCategoriesAction(): Promise<ApiResponse<CategoryResponse[]>> {
+  const response = await categoryApi.getAll()
+  return response
 }

--- a/src/features/keyword.action.ts
+++ b/src/features/keyword.action.ts
@@ -1,14 +1,13 @@
 'use server'
 
 import { keywordApi, KeywordResponse } from '@/services/keyword/keyword.service'
+import { ApiResponse } from '@/types/mypage-shorts'
 
-export async function getKeywordsAction(): Promise<KeywordResponse[]> {
+export async function getKeywordsAction(): Promise<ApiResponse<KeywordResponse[]>> {
   try {
-    const result = await keywordApi.getAll()
-    console.log('키워드 API 응답:', JSON.stringify(result, null, 2))
-    return result
+    return await keywordApi.getAll()
   } catch (error) {
-    console.error('키워드 목록 조회 실패:', error)
-    return []
+    console.log('키워드 조회 실패', error)
+    return { success: false, code: 'ERROR', message: '키워드 조회 실패', data: [] }
   }
 }

--- a/src/features/register/components/ShortsFormCategory.tsx
+++ b/src/features/register/components/ShortsFormCategory.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { getCategoriesAction } from '@/features/category.action'
-import type { Category } from '@/services/category/category.service'
+import { CategoryResponse } from '@/services/category/category.service'
 import { ChevronDown } from 'lucide-react'
 import { useEffect, useState, type ChangeEvent } from 'react'
 
@@ -15,9 +15,8 @@ export default function ShortsFormCategory({ value, onChange }: ShortsFormCatego
 
   useEffect(() => {
     const fetchCategories = async () => {
-      const data = await getCategoriesAction()
-      console.log(data)
-      setCategories(data)
+      const res = await getCategoriesAction()
+      setCategories(res.data)
     }
 
     fetchCategories()

--- a/src/hook/keyword/useKeywordSearch.ts
+++ b/src/hook/keyword/useKeywordSearch.ts
@@ -44,8 +44,10 @@ export default function useKeywordSearch({
     isFetchingRef.current = true
     try {
       const result = await getKeywordsAction()
-      keywordCacheRef.current = result
-      return result
+      if (result.success && result.data) {
+        keywordCacheRef.current = result.data
+      }
+      return result.data
     } finally {
       isFetchingRef.current = false
     }

--- a/src/services/category/category.service.ts
+++ b/src/services/category/category.service.ts
@@ -1,17 +1,13 @@
 import { api } from '@/lib/utils/apiUtils'
+import { ApiResponse } from '@/types/mypage-shorts'
 
-export interface Category {
+export interface CategoryResponse {
   id: number
   name: string
 }
 
-interface CategoryListResponse {
-  data: CategoryResponse[]
-}
-
 export const categoryApi = {
-  getAll: async (): Promise<CategoryResponse[]> => {
-    const response = await api.get<CategoryListResponse>('/api/v1/categories')
-    return response.data ?? []
+  getAll: async (): Promise<ApiResponse<CategoryResponse[]>> => {
+    return api.get<ApiResponse<CategoryResponse[]>>('/api/v1/categories')
   },
 }

--- a/src/services/keyword/keyword.service.ts
+++ b/src/services/keyword/keyword.service.ts
@@ -1,4 +1,5 @@
 import { api } from '@/lib/utils/apiUtils'
+import { ApiResponse } from '@/types/mypage-shorts'
 
 export interface KeywordResponse {
   id: number
@@ -6,17 +7,9 @@ export interface KeywordResponse {
   normalizedName: string
 }
 
-interface KeywordListResponse {
-  data: KeywordResponse[]
-}
-
 export const keywordApi = {
-  getAll: async (): Promise<KeywordResponse[]> => {
-    const response = await api.get<KeywordListResponse | KeywordResponse[]>('/api/v1/keywords')
-    // 응답이 { data: [...] } 형태인지 배열인지 확인
-    if (Array.isArray(response)) {
-      return response
-    }
-    return response.data ?? []
+  getAll: async (): Promise<ApiResponse<KeywordResponse[]>> => {
+    const response = await api.get<ApiResponse<KeywordResponse[]>>('/api/v1/keywords')
+    return response
   },
 }


### PR DESCRIPTION
## 변경 사항

- category.service, keyword.service에서 ApiResponse<T> 타입 적용
- 불필요한 중간 인터페이스(CategoryListResponse, KeywordListResponse) 제거
- 서비스 레이어의 응답 언래핑 로직을 호출부로 이동
- useKeywordSearch에서 응답 success 체크 로직 추가
- 디버그용 console.log 정리

## 리뷰 필요

- 타입 정의 확인
-

close #227 