### PR TITLE
fix: 내 숏츠 목록 숏츠 카드 hydration 오류 및 이미지 최적화 이슈 수정

### DIFF
--- a/src/components/mypage/shorts/ShortsCard.tsx
+++ b/src/components/mypage/shorts/ShortsCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import { MoreHorizontal } from 'lucide-react'
 import type { ShortsResponse } from '@/types/mypage-shorts'
 import ShortsCardThumbnail from './ShortsCardThumbnail'
@@ -24,6 +25,14 @@ export default function ShortsCard({
   onToggleVisibility,
   onDelete,
 }: ShortsCardProps) {
+  const [timeAgoText, setTimeAgoText] = useState<string>('')
+
+  useEffect(() => {
+    if (shorts.createdAt) {
+      setTimeAgoText(timeAgo(shorts.createdAt))
+    }
+  }, [shorts.createdAt])
+
   return (
     <div
       onClick={onSelect}
@@ -45,7 +54,7 @@ export default function ShortsCard({
             <h3 className="pt-1 text-lg font-bold text-gray-900">{shorts.title}</h3>
             <p className="mt-1.5 mb-4 text-sm text-gray-500">
               {shorts.userNickname ?? '숏터'}
-              {shorts.createdAt && ` · ${timeAgo(shorts.createdAt)}`}
+              {timeAgoText && ` · ${timeAgoText}`}
             </p>
             <p className="mb-1 line-clamp-2 text-sm text-gray-700">{shorts.description}</p>
           </div>

--- a/src/components/mypage/shorts/ShortsCardThumbnail.tsx
+++ b/src/components/mypage/shorts/ShortsCardThumbnail.tsx
@@ -21,6 +21,7 @@ export default function ShortsCardThumbnail({
         fill
         sizes="(min-width: 640px) 144px, 112px"
         className="object-cover"
+        unoptimized
       />
       {/* 카테고리 */}
       {shorts.categoryName && (

--- a/src/types/mypage-shorts.ts
+++ b/src/types/mypage-shorts.ts
@@ -34,22 +34,6 @@ export interface CategoryDto {
 // 숏츠 응답 타입
 // ============================================
 export interface ShortsResponse {
-  // shortsId?: number
-  // title?: string
-  // description?: string
-  // videoUrl?: string
-  // thumbnailUrl?: string
-  // durationSec?: number
-  // keywords?: string[]
-  // status?: ShortsStatus
-  // viewCount?: number
-  // likeCount?: number
-  // commentCount?: number
-  // uploader?: UploaderDto
-  // category?: CategoryDto
-  // createdAt?: string
-  // updatedAt?: string
-
   shortsId?: number
   title?: string
   description?: string


### PR DESCRIPTION

## 변경 사항

- 숏츠 카드의 시간 표시(timeAgo)를 클라이언트 사이드에서 처리하도록 변경하여 hydration 오류 해결
  - 서버 렌더링 시점과 클라이언트 렌더링 시점이 달라 Hydration mismatch 에러 발생
  - useEffect는 클라이언트에서만 실행되므로 Hydration 불일치 해결
- 썸네일 이미지에 `unoptimized` 속성 추가하여 외부 이미지 로딩 이슈 수정
- `ShortsResponse` 타입 파일에서 불필요한 주석 코드 정리

## 리뷰 필요

- [ ] 숏츠 목록 페이지에서 hydration 오류가 발생하지 않는지 확인
- [ ] 썸네일 이미지가 정상적으로 표시되는지 확인
- [ ] 시간 표시(예: "3일 전")가 올바르게 렌더링되는지 확인

close #266 